### PR TITLE
fix: sigil issue

### DIFF
--- a/lib/today_web/views/page_view.ex
+++ b/lib/today_web/views/page_view.ex
@@ -3,23 +3,27 @@ defmodule TodayWeb.PageView do
 
   use TodayWeb, :view
 
+  @spec display_years(any) :: Phoenix.LiveView.Rendered.t()
   def display_years(assigns) do
     ~H"""
     <h2><%= @account.username %></h2>
     <%= for year <- @account.years do %>
       <h3><%= year %></h3>
-      <%= display_twitter_link(@account.username, year, @day, @month) %>
+      <%= display_twitter_link(assigns, year) %>
       <p></p>
     <% end %>
 
     """
   end
 
-  def display_twitter_link(account, year, day, month) do
-    link = Links.generate_twitter_link(account, year)
+  def display_twitter_link(
+        %{account: %{username: username}, day: day, month: month} = assigns,
+        year
+      ) do
+    link = Links.generate_twitter_link(username, year)
 
-    ~E"""
-    <p><a href="<%= link %>" target="_blank">These are your tweets for <%= day %>.<%= month %>.<%= year %></a></p>
+    ~H"""
+    <p><a href={link} target="_blank">These are your tweets for <%= day %>.<%= month %>.<%= year %></a></p>
     """
   end
 end


### PR DESCRIPTION
Fixed the issue that was causing me to use the deprecated sigil `~E`. THe problem was that I was trying to display a dynamically generated link like this:

```elixir
  ~E"""
    <p><a href="<%= link %>" target="_blank">These are your tweets for <%= day %>.<%= month %>.<%= year %></a></p>
    """
```

and it was supposed to be like this:

```elixir
 ~H"""
    <p><a href={link} target="_blank">These are your tweets for <%= day %>.<%= month %>.<%= year %></a></p>
    """
```

